### PR TITLE
change extension manager to be read only

### DIFF
--- a/submit.yml.erb
+++ b/submit.yml.erb
@@ -69,6 +69,8 @@ script:
             c.ServerApp.root_dir = '<%= user.home %>'
             c.ServerApp.disable_check_xsrf = True
             c.LabApp.check_for_updates_class = 'jupyterlab.NeverCheckForUpdate'
+            c.LabApp.extension_manager = 'readonly'
+            c.PluginManager.level = 'user'
           mount_path: '/ood'
     init_containers:
     - name: "init-secret"


### PR DESCRIPTION
- packages installs by extension manager were failing due to permissions errors
- also change plugin manager level to 'user' so that enabling/disabling extensions via extension manager works