### PR TITLE
shared kernels now work in the same way as on mahuika

### DIFF
--- a/submit.yml.erb
+++ b/submit.yml.erb
@@ -33,6 +33,7 @@ script:
         SHELL: "/bin/bash"
         LMOD_SITE_MODULEPATH: "/opt/nesi/CS400_centos7_bdw/modules/all"
         TZ: 'Pacific/Auckland'
+        JUPYTER_JOB_ACCOUNT: "<%= account %>"
       port: "8080"
       cpu: "<%= num_cores %>"
       memory: "<%= num_mem %>Gi"

--- a/template/script.sh.erb
+++ b/template/script.sh.erb
@@ -36,6 +36,10 @@ echo "TIMING - Starting jupyter at: $(date)"
 # copying config file for debugging
 cp /ood/ondemand_config.py "${SESSION_DIR}"
 
+# set JUPYTER_PATH to include shared custom kernels created by nesi-add-kernel
+export JUPYTER_PATH=/nesi/project/${JUPYTER_JOB_ACCOUNT}/.jupyter/share/jupyter:${JUPYTER_PATH}
+echo "Extending JUPYTER_PATH to include shared kernels from \"/nesi/project/${JUPYTER_JOB_ACCOUNT}\""
+
 # Launch the Jupyter Notebook Server
 set -x
 jupyter lab --config="/ood/ondemand_config.py" <%= context.extra_jupyter_args %>


### PR DESCRIPTION
- set `JUPYTER_JOB_ACCOUNT` env var to the account specified on the launch form - this is used by `nesi-add-kernel` when creating the shared kernel and by *script.sh* when extending `JUPYTER_PATH`
- extend `JUPYTER_PATH` in *script.sh* to include any shared kernels from the project directory