### PR TITLE
Add empty NeSI module and mount homes at scale_wlg location too

### DIFF
--- a/submit.yml.erb
+++ b/submit.yml.erb
@@ -75,6 +75,11 @@ script:
         path: /home
         destination_path: /home
       - type: nfs
+        name: wlghome
+        host: <%= weka_nfs_server %>
+        path: /home
+        destination_path: /scale_wlg_persistent/filesets/home
+      - type: nfs
         name: project
         host: <%= weka_nfs_server %>
         path: /project

--- a/template/modules/NeSI.lua
+++ b/template/modules/NeSI.lua
@@ -1,0 +1,7 @@
+help([[
+Description
+===========
+This is a temporary workaround to ensure custom kernels created on mahuika continue to work.
+]])
+
+whatis("Description: This is a temporary workaround to ensure custom kernels created on mahuika continue to work.")


### PR DESCRIPTION
To ensure venvs and custom kernels created on mahuika continue to work