### PR TITLE
HPC-649: bump base image to v0.10.4

### DIFF
--- a/submit.yml.erb
+++ b/submit.yml.erb
@@ -53,7 +53,7 @@ script:
   native:
     container:
       name: "<%= account.present? ? "jupyterlab-#{account}" : 'jupyterlab' %>"
-      image: "ghcr.io/nesi/nesi-docker-base:v0.10.3"
+      image: "ghcr.io/nesi/nesi-docker-base:v0.10.4"
       command: ["/bin/bash","-l","<%= staged_root %>/job_script_content.sh"]
       working_dir: "<%= Etc.getpwnam(ENV['USER']).dir %>"
       restart_policy: 'OnFailure'


### PR DESCRIPTION
## Issue

https://nznesi.atlassian.net/browse/HPC-649

Merging this PR does not transition the issue. That is a manual step, owned by whoever merges.

## What Changed

Bumped the container base image in `submit.yml.erb` from `ghcr.io/nesi/nesi-docker-base:v0.10.3` to `ghcr.io/nesi/nesi-docker-base:v0.10.4`, so this app runs the current base layer instead of the superseded one. One line changes; no behaviour, form logic or Slurm submission argument is altered.

## Applications in This Change

All ten OnDemand interactive apps were pinned at v0.10.3 and are moving to v0.10.4. Six use `nesi-docker-base`, four use `nesi-ondemand-vnc`.

| Application | Image | PR |
|---|---|---|
| `nesi-ood-Avogadro2-app` | nesi-ondemand-vnc | https://github.com/nesi/nesi-ood-Avogadro2-app/pull/1 |
| `nesi-ood-codeserver-app` | nesi-docker-base | https://github.com/nesi/nesi-ood-codeserver-app/pull/23 |
| `nesi-ood-fluent-server-app` | nesi-docker-base | not yet open — pending write access, see below |
| `nesi-ood-jupyterlab-app` | nesi-docker-base | this PR |
| `nesi-ood-matlab-server-app` | nesi-docker-base | https://github.com/nesi/nesi-ood-matlab-server-app/pull/9 |
| `nesi-ood-pluto-app` | nesi-docker-base | https://github.com/nesi/nesi-ood-pluto-app/pull/1 |
| `nesi-ood-pymol-app` | nesi-ondemand-vnc | https://github.com/nesi/nesi-ood-pymol-app/pull/1 |
| `nesi-ood-rstudio-server-app` | nesi-docker-base | https://github.com/nesi/nesi-ood-rstudio-server-app/pull/39 |
| `nesi-ood-virtualdesktop-app` | nesi-ondemand-vnc | https://github.com/nesi/nesi-ood-virtualdesktop-app/pull/21 |
| `nesi-ood-VMD-app` | nesi-ondemand-vnc | https://github.com/nesi/nesi-ood-VMD-app/pull/1 |

Nine of the ten are open. `nesi-ood-fluent-server-app` is still outstanding: the authoring account has no write access to that repo. Its commit is prepared locally and identical in shape to this one, and it will be opened as a PR once access is granted. Reviewers should know the set is not yet complete.

## Version

| | |
|---|---|
| Current | v0.22.4 |
| Proposed | v0.22.5 |
| Level | patch |
| Why | container base image bump — nothing user-visible changes |

Tagged after merge, not before. Each app versions independently from its own current tag; these numbers do not move in lockstep across the ten repos.

## Gate

- [x] Diff read line by line
- [x] ERB delimiters balanced (`<%` / `%>` / `<%=` / `<%-`)
- [ ] `my-k8s-cluster` path still produces a working session
- [ ] Slurm / `nesi_tdc_hpc` path still produces a working session
- [x] `form.yml.erb` project-code special cases unaffected (`restricted_projects`, `nesi_training_projects`, `nesi-staff` / `ondemand-slurm-apps` gating)
- [x] New container tag exists in ghcr.io and is pinned, not moving
- [ ] Session launched through the OnDemand dashboard

Not verified, and why:

- **`my-k8s-cluster` session** — not launched. No OnDemand dashboard access from the working environment. The edit is confined to the image tag inside this branch, but that the new image actually boots this app has **not** been observed here and needs a human check.
- **Slurm / `nesi_tdc_hpc` session** — not launched, and n/a — the `image:` pin sits inside the `if cluster == "my-k8s-cluster"` branch. The Slurm `else` branch passes sbatch native args and names no container, so it is untouched by construction.
- **Session through the dashboard** — not launched, same reason as above.
- **ERB syntax check** — Ruby is not installed on the working machine, so `erb -x` and `ruby -c` are unavailable and no ERB file was syntax-checked. The delimiter tick above is a read plus a delimiter count compared against `main` (identical before and after), not a tool run. The changed text sits inside a double-quoted YAML scalar and adds or removes no ERB delimiters.
- **`form.yml.erb` tick** — verified by the file being absent from the diff, not by exercising the form. The commit touches `submit.yml.erb` only.

## Acceptance Criteria

- [x] Each of the ten `submit.yml.erb` files pins its image at `v0.10.4`, and `grep -rn "v0.10.3"` across all ten repos returns nothing — done locally in all ten; one is not yet pushed.
- [x] The diff in each repo is exactly one changed line, with no whitespace or unrelated edits.
- [x] Both `ghcr.io/nesi/nesi-docker-base:v0.10.4` and `ghcr.io/nesi/nesi-ondemand-vnc:v0.10.4` resolve in ghcr.io and are pinned tags, not moving ones.
- [ ] Ten PRs are open, one per repo, each against `main`, each linking the other nine — **not met yet.** Nine are open; `nesi-ood-fluent-server-app` is blocked on write access.
- [ ] A session launched from the OnDemand dashboard on my-k8s-cluster starts and its Connect button opens a working app — **not met.** No dashboard access here; needs a human.
- [ ] After a human merges, each repo carries a new patch tag and a published GitHub Release — pending merge.

## Evidence

Diff on this repo:

```
@@ -56 +56 @@ script:
-      image: "ghcr.io/nesi/nesi-docker-base:v0.10.3"
+      image: "ghcr.io/nesi/nesi-docker-base:v0.10.4"
```

Diff is one file, one insertion, one deletion:

```
 1 file changed, 1 insertion(+), 1 deletion(-)
```

Both new tags confirmed present in ghcr.io on 2026-08-25 via the registry tag list API, and both are pinned `vX.Y.Z` tags rather than moving ones such as `latest`:

```
nesi-docker-base    -> v0.10.3, v0.10.4
nesi-ondemand-vnc   -> v0.10.3, v0.10.4
```

ERB delimiter count for `submit.yml.erb`, `main` versus this branch:

```
  main        35 %>
  main        35 <%
  branch      35 %>
  branch      35 <%
```

## Rollback

Revert the commit on `main` and cut a patch release restoring `ghcr.io/nesi/nesi-docker-base:v0.10.3`. The change is a single pinned image tag, so the revert is exact and carries no data or state migration.
